### PR TITLE
Remove invalid Next.js appDir option

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'export',
-  appDir: true,
   trailingSlash: true,
 }
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- update `next.config.js` to drop deprecated `appDir` option

## Testing
- `npm run dev`