### PR TITLE
Add auto-open to dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project is a [Next.js](https://nextjs.org/) application that statically exp
 
 ## Development Workflow
 
-During development, run the built‑in dev server. This provides hot reloading and runs the site at `http://localhost:3000` by default.
+During development, run the built‑in dev server. This provides hot reloading and runs the site at `http://localhost:3000` by default. The dev command automatically opens the site in your default browser once the server is ready.
 
 ```bash
 npm run dev

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "main.js",
   "scripts": {
     "build": "next build",
-    "dev": "next dev",
+    "dev": "node scripts/dev.js",
     "start": "next start"
   },
   "keywords": [],
@@ -17,6 +17,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "remark": "^15.0.1",
-    "remark-html": "^16.0.1"
+    "remark-html": "^16.0.1",
+    "open": "^9.1.0"
   }
 }

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -1,0 +1,19 @@
+const { spawn } = require('child_process');
+const open = require('open');
+
+// Start the Next.js dev server
+const dev = spawn('npx', ['next', 'dev'], { stdio: ['ignore', 'pipe', 'inherit'], shell: true });
+
+let opened = false;
+
+dev.stdout.on('data', (data) => {
+  const text = data.toString();
+  process.stdout.write(text);
+  if (!opened && text.includes('started server')) {
+    opened = true;
+    open('http://localhost:3000');
+  }
+});
+
+dev.on('close', (code) => process.exit(code));
+


### PR DESCRIPTION
## Summary
- run Next dev server through a small script
- launch default browser when the server is ready
- document automatic browser launch

## Testing
- `node -v`
- `npm --version`