### PR TITLE
Improve responsive fonts in service cards

### DIFF
--- a/app/components/ServicesCarousel.module.css
+++ b/app/components/ServicesCarousel.module.css
@@ -64,7 +64,7 @@
 /* Title */
 .card h3 {
   font-family: var(--font-primary);
-  font-size: 1.25rem;
+    font-size: clamp(1.25rem, calc(1.07rem + 0.056vw), 1.5rem);
   color: var(--color-accent);
   margin: 0.5rem 0 1rem;
 }
@@ -72,9 +72,9 @@
 /* Description – Mini Portrait */
 .card p {
   font-family: var(--font-secondary);
-  font-size: 1rem;
+  font-size: clamp(1rem, calc(0.9rem + 0.06vw), 1.25rem);
   color: var(--color-text);
-  line-height: 1.5;
+  line-height: 1.6;
   flex-grow: 1;
   margin-bottom: 1rem;
 }
@@ -104,8 +104,7 @@
     flex: 0 0 85%;               /* show a bit of next card */
   }
   .card p {
-    font-size: 1.05rem;
-    line-height: 1.5;
+    line-height: 1.6;
   }
 }
 
@@ -120,7 +119,6 @@
     gap: 1.5rem;                 /* loosen gap for finger taps */
   }
   .card p {
-    font-size: 1.25rem;          /* more readable on small phone */
     line-height: 1.6;
   }
 }
@@ -142,7 +140,7 @@
    ───────────────────────────────────────────────────────────────────────────── */
 @media (min-width: 1024px) {
   .card p {
-    font-size: 1rem;       
-    line-height: 1.5;
+    font-size: clamp(1rem, calc(0.9rem + 0.06vw), 1.25rem);       
+    line-height: 1.6;
   }
 }


### PR DESCRIPTION
## Summary
- use CSS `clamp` to scale card titles and body text
- set base card paragraph line-height to `1.6`
- remove redundant font sizes in media queries

## Testing
- `npm run build`