### PR TITLE
Add Jest testing setup

### DIFF
--- a/app/components/ServicesCarousel.test.jsx
+++ b/app/components/ServicesCarousel.test.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import ServicesCarousel from './ServicesCarousel';
+
+describe('ServicesCarousel', () => {
+  it('renders service titles', () => {
+    const services = [
+      { slug: 'a', image: '/a.png', alt: 'a', title: 'Title A', description: 'Desc' },
+    ];
+    render(<ServicesCarousel services={services} />);
+    expect(screen.getByText('Title A')).toBeInTheDocument();
+  });
+});

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,7 @@
+export default {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['@testing-library/jest-dom/extend-expect'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+};

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "next build",
     "dev": "next dev",
-    "start": "next start"
+    "start": "next start",
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
@@ -18,5 +19,13 @@
     "react-dom": "^19.1.0",
     "remark": "^15.0.1",
     "remark-html": "^16.0.1"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/react": "^15.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library configuration
- define `test` npm script
- create sample test for `ServicesCarousel`

## Testing
- `npm install` *(fails: unable to fetch packages)*
- `npm test` *(fails: jest: not found)*