### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18.x'
+      - run: npm ci
+      - run: npm run build
+      - name: Upload build output
+        uses: actions/upload-artifact@v4
+        with:
+          name: static-site
+          path: out
+      # Uncomment the following steps to deploy to GitHub Pages
+      #- name: Setup Pages
+      #  uses: actions/configure-pages@v4
+      #- name: Upload Pages artifact
+      #  uses: actions/upload-pages-artifact@v2
+      #  with:
+      #    path: out
+      #- name: Deploy to GitHub Pages
+      #  id: deployment
+      #  uses: actions/deploy-pages@v2
+      #  with:
+      #    artifact_name: github-pages
+

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ The contents of `out/` can be deployed to any static hosting provider.
 
 Images referenced in the Markdown live under `public/images/`, which is listed in `.gitignore`. You will need to supply your own images in that folder when running the site locally.
 
+## Continuous Integration
+
+This repository includes a GitHub Actions workflow (`.github/workflows/ci.yml`) that runs on every push and pull request to `main`. It installs dependencies with `npm ci`, builds the project, and uploads the `out/` directory as an artifact. Uncomment the deployment steps in the workflow to publish the site automatically to GitHub Pages or adapt it for another host such as Netlify.
+
+Create a branch protection rule for `main` so that pull requests must pass this workflow before they can be merged.
+
 ## Additional Notes
 
 - To start the production server (useful for previewing the build locally), run:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow with Node 18
- document the CI/CD pipeline in the README

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*
