### PR TITLE
Add dynamic service page and stubs

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import '../styles/style.css'
+import Script from 'next/script'
+
+interface LayoutProps {
+  children: React.ReactNode
+}
+
+const Layout: React.FC<LayoutProps> = ({ children }) => (
+  <>
+    <main>{children}</main>
+    <footer className="site-footer">
+      <div className="container footer-content">
+        <div className="footer-brand">
+          <a href="/" className="logo">Ely Aesthetics</a>
+        </div>
+        <div className="footer-contact">
+          <p>
+            Address: <a target="_blank" rel="noopener noreferrer" href="https://www.google.com/maps/place/Ely+Esthetics/@32.7167633,-114.6242984,17z/data=!3m1!4b1!4m6!3m5!1s0x80d6f76ac597dd9f:0x2acce267d196eccd!8m2!3d32.7167633!4d-114.6242984!16s%2Fg%2F11k50850n2?coh=164777&entry=tt&shorturl=1">561 S 4th Ave, Yuma, AZ</a>
+          </p>
+          <p>
+            Message me at: <a href="tel:(928)581-0046">928-581-0046</a> or <a href="https://instagram.com/elyzmanyfacez" target="_blank" rel="noopener">Instagram</a>
+          </p>
+          <div className="social-links">
+            <a href="https://instagram.com/elyzmanyfacez" target="_blank" rel="noopener">
+              Instagram
+            </a>
+          </div>
+        </div>
+        <div className="footer-legal">
+          <p>&copy; {new Date().getFullYear()} Ely Aesthetics. All rights reserved.</p>
+          <a href="/privacy">Privacy Policy</a>&nbsp;|&nbsp;<a href="/terms">Terms of Service</a>
+        </div>
+      </div>
+    </footer>
+    <Script src="/main.js" strategy="afterInteractive" />
+  </>
+)
+
+export default Layout

--- a/components/services/Breadcrumb.tsx
+++ b/components/services/Breadcrumb.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export interface BreadcrumbProps {
+  slug: string
+  title: string
+}
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ slug, title }) => (
+  <nav aria-label="breadcrumb">
+    <ol>
+      <li><a href="/">Home</a></li>
+      <li><a href="/services">Services</a></li>
+      <li aria-current="page">{title}</li>
+    </ol>
+  </nav>
+)

--- a/components/services/FAQAccordion.tsx
+++ b/components/services/FAQAccordion.tsx
@@ -1,0 +1,11 @@
+import React, { useState } from 'react'
+
+export interface FAQItem { q: string; a: string }
+export interface FAQAccordionProps { faq: FAQItem[] }
+
+export const FAQAccordion: React.FC<FAQAccordionProps> = ({ faq }) => (
+  <section>
+    <h2>FAQ</h2>
+    {faq.map(({ q, a }, i) => <details key={i}><summary>{q}</summary><p>{a}</p></details>)}
+  </section>
+)

--- a/components/services/Gallery.tsx
+++ b/components/services/Gallery.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+
+export interface GalleryProps {
+  images: string[]
+}
+
+export const Gallery: React.FC<GalleryProps> = ({ images }) => (
+  <section>
+    <h2>Before & After</h2>
+    <div>
+      {images.map((src, i) => (<img key={i} src={src} alt="Service gallery image" />))}
+    </div>
+  </section>
+)

--- a/components/services/HowItWorks.tsx
+++ b/components/services/HowItWorks.tsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export interface Step {
+  title: string
+  icon: string
+}
+export interface HowItWorksProps {
+  steps: Step[]
+}
+
+export const HowItWorks: React.FC<HowItWorksProps> = ({ steps }) => (
+  <section>
+    <h2>How It Works</h2>
+    <div>
+      {steps.map((step, i) => (
+        <div key={i}>
+          {/* TODO: render icon */}
+          <p>{step.title}</p>
+        </div>
+      ))}
+    </div>
+  </section>
+)

--- a/components/services/OverviewBenefits.tsx
+++ b/components/services/OverviewBenefits.tsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+export interface OverviewBenefitsProps {
+  overview: string
+  benefits: string[]
+}
+
+export const OverviewBenefits: React.FC<OverviewBenefitsProps> = ({ overview, benefits }) => (
+  <section>
+    <div>
+      <h2>What It Is</h2>
+      <p>{overview}</p>
+    </div>
+    <div>
+      <h2>Key Benefits</h2>
+      <ul>
+        {benefits.map((b, i) => (<li key={i}>{b}</li>))}
+      </ul>
+    </div>
+  </section>
+)

--- a/components/services/ServiceHero.tsx
+++ b/components/services/ServiceHero.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export interface ServiceHeroProps {
+  videoUrl: string
+  poster: string
+  title: string
+  subtitle: string
+  ctaText: string
+}
+
+export const ServiceHero: React.FC<ServiceHeroProps> = ({ videoUrl, poster, title, subtitle, ctaText }) => (
+  <section>
+    {/* TODO: implement video background with overlay */}
+    <h1>{title}</h1>
+    <p>{subtitle}</p>
+    <button>{ctaText}</button>
+  </section>
+)

--- a/components/services/StickyBookingBar.tsx
+++ b/components/services/StickyBookingBar.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export interface StickyBookingBarProps { serviceName: string; price: number }
+
+export const StickyBookingBar: React.FC<StickyBookingBarProps> = ({ serviceName, price }) => (
+  <div style={{ position: 'fixed', bottom: 0, width: '100%' }}>
+    <span>{serviceName} – ${price}</span>
+    <button>Book Now</button>
+  </div>
+)

--- a/components/services/TestimonialsCarousel.tsx
+++ b/components/services/TestimonialsCarousel.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export interface Testimonial { name: string; quote: string; image: string }
+export interface TestimonialsCarouselProps { testimonials: Testimonial[] }
+
+export const TestimonialsCarousel: React.FC<TestimonialsCarouselProps> = ({ testimonials }) => (
+  <section>
+    <h2>Testimonials</h2>
+    <div>
+      {testimonials.map((t, i) => (
+        <blockquote key={i}>
+          <p>“{t.quote}”</p>
+          <footer>- {t.name}</footer>
+        </blockquote>
+      ))}
+    </div>
+  </section>
+)

--- a/components/services/index.ts
+++ b/components/services/index.ts
@@ -1,0 +1,8 @@
+export { ServiceHero } from './ServiceHero'
+export { Breadcrumb } from './Breadcrumb'
+export { OverviewBenefits } from './OverviewBenefits'
+export { HowItWorks } from './HowItWorks'
+export { Gallery } from './Gallery'
+export { FAQAccordion } from './FAQAccordion'
+export { TestimonialsCarousel } from './TestimonialsCarousel'
+export { StickyBookingBar } from './StickyBookingBar'

--- a/pages/services/[slug].tsx
+++ b/pages/services/[slug].tsx
@@ -1,0 +1,64 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { GetStaticPaths, GetStaticProps } from 'next'
+import Layout from '../../components/Layout'
+import {
+  ServiceHero,
+  Breadcrumb,
+  OverviewBenefits,
+  HowItWorks,
+  Gallery,
+  FAQAccordion,
+  TestimonialsCarousel,
+  StickyBookingBar,
+} from '../../components/services'
+
+interface ServiceProps {
+  frontMatter: any
+  content: string
+  slug: string
+}
+
+const ServicePage: React.FC<ServiceProps> = ({ frontMatter, content, slug }) => {
+  return (
+    <Layout>
+      <ServiceHero
+        videoUrl={frontMatter.video}
+        poster={frontMatter.poster}
+        title={frontMatter.title}
+        subtitle={frontMatter.subtitle}
+        ctaText="Book This Treatment"
+      />
+      <Breadcrumb slug={slug} title={frontMatter.title} />
+      <OverviewBenefits overview={frontMatter.overview} benefits={frontMatter.benefits} />
+      <HowItWorks steps={frontMatter.steps} />
+      <Gallery images={frontMatter.gallery} />
+      <FAQAccordion faq={frontMatter.faq} />
+      <TestimonialsCarousel testimonials={frontMatter.testimonials} />
+      <StickyBookingBar serviceName={frontMatter.title} price={frontMatter.price} />
+    </Layout>
+  )
+}
+
+export const getStaticPaths: GetStaticPaths = async () => {
+  const files = fs.readdirSync(path.join(process.cwd(), 'content/services'))
+  const paths = files.map((filename) => ({
+    params: { slug: filename.replace(/\.mdx?$/, '') },
+  }))
+
+  return { paths, fallback: false }
+}
+
+export const getStaticProps: GetStaticProps = async ({ params }) => {
+  const slug = params?.slug as string
+  const filePath = path.join(process.cwd(), 'content/services', `${slug}.md`)
+  const fileContent = fs.readFileSync(filePath, 'utf-8')
+  const { data: frontMatter, content } = matter(fileContent)
+
+  return {
+    props: { frontMatter, content, slug },
+  }
+}
+
+export default ServicePage


### PR DESCRIPTION
## Summary
- implement dynamic service page under pages/services/[slug]
- add layout component and service component stubs

## Testing
- `npm run build` *(fails: requires typescript packages)*