### PR TITLE
Add Cypress E2E test for booking flow

### DIFF
--- a/app/components/ServicesCarousel.jsx
+++ b/app/components/ServicesCarousel.jsx
@@ -25,7 +25,7 @@ export default function ServicesCarousel({ services }) {
 
         <div className={styles.list} ref={list}>
           {services.map(svc => (
-            <article key={svc.slug} className={styles.card}>
+            <article data-cy="service-card" key={svc.slug} className={styles.card}>
               <div className={`card-img ${styles.img}`}>
                 <img src={svc.image} alt={svc.alt} loading="lazy" />
               </div>

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -110,6 +110,7 @@ export default function HomePage() {
             this facial.
           </p>
           <button
+            data-cy="book-now-button"
             className="btn btn-primary"
             onClick={() => {
               window.dispatchEvent(

--- a/components/BookingModal.tsx
+++ b/components/BookingModal.tsx
@@ -22,7 +22,10 @@ export const BookingModal: React.FC = () => {
 
   if (!isOpen) return null
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+    <div
+      data-cy="booking-modal"
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center"
+    >
       <div className="bg-white rounded-2xl p-6 max-w-md w-full">
         <h3 className="text-xl font-semibold mb-4">Book Your {service}</h3>
         {/* Insert your booking form component here, preloaded with `service` */}

--- a/components/services/ServiceHero.tsx
+++ b/components/services/ServiceHero.tsx
@@ -34,6 +34,7 @@ export const ServiceHero: React.FC<ServiceHeroProps> = ({
         {subtitle}
       </p>
       <button
+        data-cy="book-now-button"
         className="bg-accent text-white py-3 px-6 rounded-2xl shadow-lg hover:opacity-90 transition"
         onClick={() =>
           window.dispatchEvent(

--- a/components/services/StickyBookingBar.tsx
+++ b/components/services/StickyBookingBar.tsx
@@ -8,6 +8,7 @@ export const StickyBookingBar: React.FC<StickyBookingBarProps> = ({ serviceName,
       {serviceName} – ${price}
     </span>
     <button
+      data-cy="book-now-button"
       className="bg-accent text-white py-2 px-4 rounded-lg hover:opacity-90 transition"
       onClick={() =>
         window.dispatchEvent(new CustomEvent('open-booking', { detail: { service: serviceName } }))

--- a/cypress/integration/service-flow.spec.js
+++ b/cypress/integration/service-flow.spec.js
@@ -1,0 +1,47 @@
+/// <reference types="cypress" />
+
+describe('Service Booking Flow', () => {
+  beforeEach(() => {
+    // stub GA4 gtag function before page load
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        // replace real gtag with a stub
+        cy.stub(win, 'gtag').as('gtag')
+      },
+    })
+  })
+
+  it('navigates to a service page and opens booking modal with GA4 events', () => {
+    // 1) Click the first service card
+    cy.get('[data-cy=service-card]').first().click()
+
+    // 2) Verify URL
+    cy.url().should('match', /\/services\/[a-z0-9\-]+$/)
+
+    // 3) Click the “Book Now” button
+    cy.get('[data-cy=book-now-button]').click()
+
+    // 4) Modal should be visible
+    cy.get('[data-cy=booking-modal]').should('be.visible')
+
+    // 5) gtag() should have been called for click and open
+    cy.get('@gtag').should(
+      'be.calledWith',
+      'event',
+      'service_booking_click',
+      Cypress.sinon.match({
+        service: Cypress._.first(Cypress.$('[data-cy=service-card]'))
+          .innerText.trim(),
+      }),
+    )
+    cy.get('@gtag').should(
+      'be.calledWith',
+      'event',
+      'service_booking_open',
+      Cypress.sinon.match({
+        service: Cypress._.first(Cypress.$('[data-cy=service-card]'))
+          .innerText.trim(),
+      }),
+    )
+  })
+})

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "node": ">=18"
   },
   "devDependencies": {
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "cypress": "^13.7.3"
   }
 }


### PR DESCRIPTION
## Summary
- mark service cards, booking buttons, and modal with data-cy attributes
- document GA4 events and stub them in Cypress
- add Cypress test for navigating from a service card through to the booking modal
- include Cypress in devDependencies

## Testing
- `npm run build` *(fails: `next` not found)*