### PR TITLE
Add service details pages

### DIFF
--- a/app/components/ServicesCarousel.jsx
+++ b/app/components/ServicesCarousel.jsx
@@ -25,13 +25,13 @@ export default function ServicesCarousel({ services }) {
 
         <div className={styles.list} ref={list}>
           {services.map(svc => (
-            <article key={svc.slug} className={styles.card}>
+            <a key={svc.slug} href={`/services/${svc.slug}`} className={styles.card}>
               <div className={`card-img ${styles.img}`}>
                 <img src={svc.image} alt={svc.alt} loading="lazy" />
               </div>
               <h3>{svc.title}</h3>
               <p>{svc.description}</p>
-            </article>
+            </a>
           ))}
         </div>
 

--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -1,0 +1,52 @@
+import fs from 'fs'
+import path from 'path'
+import matter from 'gray-matter'
+import { remark } from 'remark'
+import html from 'remark-html'
+import styles from './page.module.css'
+import { notFound } from 'next/navigation'
+
+function getService(slug) {
+  const dir = path.join(process.cwd(), 'content/services')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'))
+  for (const file of files) {
+    const source = fs.readFileSync(path.join(dir, file), 'utf8')
+    const { data, content } = matter(source)
+    if (data.slug === slug) {
+      return { ...data, content }
+    }
+  }
+  return null
+}
+
+export async function generateStaticParams() {
+  const dir = path.join(process.cwd(), 'content/services')
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.md'))
+  return files.map(file => {
+    const source = fs.readFileSync(path.join(dir, file), 'utf8')
+    const { data } = matter(source)
+    return { slug: data.slug }
+  })
+}
+
+export default async function ServicePage({ params }) {
+  const service = getService(params.slug)
+  if (!service) return notFound()
+  const processed = await remark().use(html).process(service.content)
+  const contentHtml = processed.toString()
+  return (
+    <div className={`container ${styles.service}`}>
+      <div className={styles.image}>
+        <img src={service.image} alt={service.alt} />
+      </div>
+      <h1 className={styles.title}>{service.title}</h1>
+      <p className={styles.description}>{service.description}</p>
+      {service.content && (
+        <div
+          className={styles.content}
+          dangerouslySetInnerHTML={{ __html: contentHtml }}
+        />
+      )}
+    </div>
+  )
+}

--- a/app/services/[slug]/page.module.css
+++ b/app/services/[slug]/page.module.css
@@ -1,0 +1,34 @@
+.service {
+  padding: 2rem 0;
+}
+
+.image {
+  width: 100%;
+  max-height: 400px;
+  overflow: hidden;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+}
+.image img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.title {
+  font-family: var(--font-primary);
+  color: var(--color-accent);
+  font-size: 2rem;
+  text-align: center;
+  margin-bottom: 1rem;
+}
+.description {
+  font-family: var(--font-secondary);
+  font-size: 1.125rem;
+  text-align: center;
+  margin-bottom: 1.5rem;
+}
+.content {
+  font-family: var(--font-secondary);
+  line-height: 1.6;
+}


### PR DESCRIPTION
## Summary
- create dynamic route under `app/services/[slug]`
- style service pages
- link carousel cards to each service detail page

## Testing
- `npm run build`