### PR TITLE
Enable service carousel links

### DIFF
--- a/app/components/ServicesCarousel.jsx
+++ b/app/components/ServicesCarousel.jsx
@@ -1,5 +1,6 @@
 'use client'
 import { useRef } from 'react'
+import Link from 'next/link'
 import styles from './ServicesCarousel.module.css'
 
 export default function ServicesCarousel({ services }) {
@@ -24,14 +25,19 @@ export default function ServicesCarousel({ services }) {
         </button>
 
         <div className={styles.list} ref={list}>
-          {services.map(svc => (
-            <article data-cy="service-card" key={svc.slug} className={styles.card}>
+          {services.map((svc) => (
+            <Link
+              key={svc.slug}
+              href={`/services/${svc.slug}`}
+              data-cy="service-card"
+              className={styles.card}
+            >
               <div className={`card-img ${styles.img}`}>
                 <img src={svc.image} alt={svc.alt} loading="lazy" />
               </div>
               <h3>{svc.title}</h3>
               <p>{svc.description}</p>
-            </article>
+            </Link>
           ))}
         </div>
 


### PR DESCRIPTION
## Summary
- make service cards clickable links to `/services/[slug]`

## Testing
- `npm run build` *(fails: npm not installed)*