### PR TITLE
Add cypress test for hero booking CTA

### DIFF
--- a/cypress/integration/hero-cta.spec.js
+++ b/cypress/integration/hero-cta.spec.js
@@ -1,0 +1,28 @@
+/// <reference types="cypress" />
+
+describe('Hero CTA Booking Modal', () => {
+  beforeEach(() => {
+    cy.visit('/', {
+      onBeforeLoad(win) {
+        cy.stub(win, 'gtag').as('gtag')
+      }
+    })
+  })
+
+  it('opens the booking modal when hero button clicked', () => {
+    cy.get('[data-cy=book-now-button]').first().click()
+    cy.get('[data-cy=booking-modal]').should('be.visible')
+    cy.get('@gtag').should(
+      'be.calledWith',
+      'event',
+      'service_booking_click',
+      Cypress.sinon.match({ service: 'Restorative Rose Facial' })
+    )
+    cy.get('@gtag').should(
+      'be.calledWith',
+      'event',
+      'service_booking_open',
+      Cypress.sinon.match({ service: 'Restorative Rose Facial' })
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- verify that the hero CTA opens the booking modal and fires GA events

## Testing
- `npm run build` *(fails: next not found)*