### PR TITLE
Fix hero CTA redirect test

### DIFF
--- a/app/components/HomePageClient.jsx
+++ b/app/components/HomePageClient.jsx
@@ -90,14 +90,13 @@ export default function HomePageClient({ services }) {
             data-cy="book-now-button"
             className="btn btn-primary"
             onClick={() => {
-              window.dispatchEvent(
-                new CustomEvent('open-booking', { detail: { service: 'Restorative Rose Facial' } })
-              )
               if (window.gtag) {
                 window.gtag('event', 'service_booking_click', {
                   service: 'Restorative Rose Facial',
                 })
               }
+              window.location.href =
+                'https://mysite.vagaro.com/sweetcreamandrose/book-now'
             }}
           >
             Book Your Facial Today!

--- a/cypress/integration/hero-cta.spec.js
+++ b/cypress/integration/hero-cta.spec.js
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-describe('Hero CTA Booking Modal', () => {
+describe('Hero CTA Booking Redirect', () => {
   beforeEach(() => {
     cy.visit('/', {
       onBeforeLoad(win) {
@@ -9,19 +9,16 @@ describe('Hero CTA Booking Modal', () => {
     })
   })
 
-  it('opens the booking modal when hero button clicked', () => {
+  it('redirects to Vagaro when hero button clicked', () => {
     cy.get('[data-cy=book-now-button]').first().click()
-    cy.get('[data-cy=booking-modal]').should('be.visible')
-    cy.get('@gtag').should(
-      'be.calledWith',
-      'event',
-      'service_booking_click',
-      Cypress.sinon.match({ service: 'Restorative Rose Facial' })
+    cy.url().should(
+      'include',
+      'mysite.vagaro.com/sweetcreamandrose/book-now'
     )
     cy.get('@gtag').should(
       'be.calledWith',
       'event',
-      'service_booking_open',
+      'service_booking_click',
       Cypress.sinon.match({ service: 'Restorative Rose Facial' })
     )
   })


### PR DESCRIPTION
## Summary
- redirect hero CTA directly to Vagaro
- check redirect in Cypress test instead of opening modal

## Testing
- `npm test` *(fails: Xvfb missing)*