### PR TITLE
Add Nav component with external Vagaro link

### DIFF
--- a/app/components/Nav.jsx
+++ b/app/components/Nav.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function Nav() {
+  return (
+    <nav className="flex items-center space-x-6">
+      {/* … other nav items … */}
+      <a
+        href="https://your.vagaro.url/?source=ely"
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-gray-800 hover:text-accent transition"
+        data-cy="nav-booking-link"
+      >
+        Book on Vagaro
+      </a>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add `Nav.jsx` component in `app/components`
- use a plain anchor tag for the external Vagaro booking link

## Testing
- `npm test` *(fails: Xvfb missing)*