### PR TITLE
Add logging for open-booking events

### DIFF
--- a/components/BookingClient.tsx
+++ b/components/BookingClient.tsx
@@ -10,7 +10,12 @@ const BookingClient: React.FC<BookingClientProps> = ({ children }) => {
   const [serviceToBook, setServiceToBook] = useState<string | null>(null)
 
   useEffect(() => {
+    console.log('[Layout] Attaching open-booking listener')
     const openHandler = (e: CustomEvent) => {
+      console.log(
+        '[Layout] open-booking event handler invoked:',
+        e.detail.service
+      )
       setServiceToBook(e.detail.service)
       if (typeof window !== 'undefined' && (window as any).gtag) {
         ;(window as any).gtag('event', 'service_booking_open', {

--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -11,7 +11,12 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
   const [serviceToBook, setServiceToBook] = useState<string | null>(null)
 
   useEffect(() => {
+    console.log('[Layout] Attaching open-booking listener')
     const openHandler = (e: CustomEvent) => {
+      console.log(
+        '[Layout] open-booking event handler invoked:',
+        e.detail.service
+      )
       setServiceToBook(e.detail.service)
       if (typeof window !== 'undefined' && (window as any).gtag) {
         ;(window as any).gtag('event', 'service_booking_open', {


### PR DESCRIPTION
## Summary
- add console debug logs when attaching `open-booking` listener
- log service name each time `open-booking` fires

## Testing
- `npm test` *(fails: Xvfb missing)*