### PR TITLE
Fix path alias resolution by updating tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,12 @@
 {
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["app/components/*"],
+      "@content/*": ["content/*"],
+      "@styles/*": ["styles/*"],
+      "@/*": ["*"]
+    },
     "target": "ES2017",
     "lib": [
       "dom",


### PR DESCRIPTION
## Summary
- add `baseUrl` and `paths` to `tsconfig.json` so that Next resolves alias imports

## Testing
- `npm test` *(fails: Xvfb missing)*