### PR TITLE
Fix path aliases for Next build

### DIFF
--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -10,7 +10,7 @@ import {
   FAQAccordion,
   TestimonialsCarousel,
   StickyBookingBar,
-} from '../../../components/services'
+} from '@components/services'
 
 /*
   generateStaticParams

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,7 +22,14 @@
         "name": "next"
       }
     ],
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["app/components/*"],
+      "@content/*": ["content/*"],
+      "@styles/*": ["styles/*"],
+      "@/*": ["*"]
+    }
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
## Summary
- use alias import for services components
- configure `tsconfig.json` with project path mappings

## Testing
- `npm run build`
- `npm test` *(fails: missing Xvfb)*