### PR TITLE
Fix service page import path

### DIFF
--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -10,7 +10,7 @@ import {
   FAQAccordion,
   TestimonialsCarousel,
   StickyBookingBar,
-} from '../../../components/services'
+} from '../../components/services'
 
 /*
   generateStaticParams


### PR DESCRIPTION
## Summary
- point the service page import to the correct components directory

## Testing
- `npm test` *(fails: missing Xvfb)*