### PR TITLE
Fix server/client component error

### DIFF
--- a/app/components/HomePageWithModal.tsx
+++ b/app/components/HomePageWithModal.tsx
@@ -1,0 +1,20 @@
+"use client"
+import { useState } from 'react'
+import Modal from './Modal'
+import HomePageClient from './HomePageClient'
+
+interface HomePageWithModalProps {
+  services: any[]
+}
+
+export default function HomePageWithModal({ services }: HomePageWithModalProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false)
+
+  return (
+    <>
+      <button onClick={() => setIsModalOpen(true)}>Book Now</button>
+      {isModalOpen && <Modal onClose={() => setIsModalOpen(false)} />}
+      <HomePageClient services={services} />
+    </>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,9 +2,7 @@
 import path from 'path'
 import fs from 'fs'
 import matter from 'gray-matter'
-import HomePageClient from './components/HomePageClient'
-import Modal from './components/Modal'
-import { useState } from 'react'
+import HomePageWithModal from './components/HomePageWithModal'
 
 
 export default function HomePage() {
@@ -28,17 +26,4 @@ export default function HomePage() {
   })
   services.sort((a, b) => a.order - b.order)
   return <HomePageWithModal services={services} />
-}
-
-function HomePageWithModal({ services }: { services: any[] }) {
-  'use client'
-  const [isModalOpen, setIsModalOpen] = useState(false)
-
-  return (
-    <>
-      <button onClick={() => setIsModalOpen(true)}>Book Now</button>
-      {isModalOpen && <Modal onClose={() => setIsModalOpen(false)} />}
-      <HomePageClient services={services} />
-    </>
-  )
 }


### PR DESCRIPTION
## Summary
- avoid React hook usage in a server component
- create `HomePageWithModal` client component
- use the new component on the homepage

## Testing
- `npm test` *(fails: missing Xvfb)*
- `npm run build`
