### PR TITLE
Add test step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         with:
           node-version: '18.x'
       - run: npm ci
+      - name: Run tests
+        run: xvfb-run --auto-servernum npm test
       - run: npm run build
       - name: Upload build output
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- run Cypress tests with `xvfb-run` in CI before building

## Testing
- `npm test` *(fails: Xvfb not installed)*
- `npm run build`
