### PR TITLE
Wrap ServiceCard in semantic article

### DIFF
--- a/app/components/ServiceCard.tsx
+++ b/app/components/ServiceCard.tsx
@@ -13,7 +13,7 @@ export interface ServiceCardProps {
 
 export default function ServiceCard({ service }: ServiceCardProps) {
   return (
-    <div className={styles.card} data-cy="service-card">
+    <article className={styles.card} data-cy="service-card">
       <div className={`card-img ${styles.img}`}>
         <img src={service.image} alt={service.alt} loading="lazy" />
       </div>
@@ -37,6 +37,6 @@ export default function ServiceCard({ service }: ServiceCardProps) {
       >
         Learn More
       </Link>
-    </div>
+    </article>
   )
 }


### PR DESCRIPTION
## Summary
- use `<article>` as the wrapper element in `ServiceCard`

## Testing
- `npm test` *(fails: missing Xvfb)*