### PR TITLE
Add About section with responsive image

### DIFF
--- a/app/components/AboutSection.jsx
+++ b/app/components/AboutSection.jsx
@@ -1,0 +1,21 @@
+'use client'
+import styles from './AboutSection.module.css'
+
+export default function AboutSection() {
+  return (
+    <section id="about" className={`about-section container ${styles.about}`}> 
+      <div className={styles.image}>
+        <img src="/images/ely_headshot.jpg" alt="Ely Aesthetics owner" />
+      </div>
+      <div className={styles.content}>
+        <h2>About Ely Aesthetics</h2>
+        <p>
+          Led by licensed esthetician Elyzia Reyes, Ely Aesthetics provides
+          personalized skin treatments that combine modern techniques with a
+          relaxing spa experience. Our Yuma studio is dedicated to helping you
+          reveal your most radiant self.
+        </p>
+      </div>
+    </section>
+  )
+}

--- a/app/components/AboutSection.module.css
+++ b/app/components/AboutSection.module.css
@@ -1,0 +1,36 @@
+/* app/components/AboutSection.module.css */
+
+.about {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  margin: 2rem 0;
+  text-align: center;
+}
+
+.image img {
+  width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.content h2 {
+  font-family: var(--font-primary);
+  color: var(--color-accent);
+  margin-bottom: 0.5rem;
+}
+
+@media (min-width: 768px) {
+  .about {
+    flex-direction: row;
+    text-align: left;
+  }
+  .image,
+  .content {
+    flex: 1;
+  }
+  .image {
+    padding-right: 1.5rem;
+  }
+}

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,6 +1,7 @@
 // app/page.js
 import Script from 'next/script'
 import SocialSection from './components/SocialSection'
+import AboutSection from './components/AboutSection'
 import path from 'path'
 import fs from 'fs'
 import matter from 'gray-matter'
@@ -123,6 +124,9 @@ export default function HomePage() {
           </button>
         </div>
       </div>
+
+      {/* About Section */}
+      <AboutSection />
 
       {/* Services Grid */}
       <ServicesCarousel services={services} />


### PR DESCRIPTION
## Summary
- create `AboutSection` component for home page
- style about section for stacked mobile layout and side-by-side desktop layout
- include the section on the home page

## Testing
- `npm run build` *(fails: next not found)*