### PR TITLE
Update SEO metadata

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -4,12 +4,17 @@ import Script from 'next/script'
 
 export const metadata = {
   title: 'Ely Aesthetics',
-  description: 'Rediscover your radiant glow with expert spa treatments.',
-  viewport: 'width=device-width, initial-scale=1',
+  description: 'Professional skincare and rejuvenating facial services in Yuma, Arizona.',
+  keywords: 'Ely Aesthetics, spa, facials, skincare, Yuma AZ',
   icons: {
     icon: '/images/favicon.ico',
     apple: '/images/favicon.ico'
   }
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
 }
 
 export default function RootLayout({ children }) {

--- a/app/page.jsx
+++ b/app/page.jsx
@@ -7,6 +7,19 @@ import fs from 'fs'
 import matter from 'gray-matter'
 import ServicesCarousel from './components/ServicesCarousel'
 
+export const metadata = {
+  title: 'Home | Ely Aesthetics',
+  description:
+    'Experience relaxing facials and advanced skincare services in Yuma, Arizona.',
+  keywords:
+    'Yuma facials, spa treatments, dermaplaning, HydraFacial, microneedling',
+}
+
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+}
+
 
 export default function HomePage() {
   // 1. Read all markdown files in content/services

--- a/old/index.html
+++ b/old/index.html
@@ -2,8 +2,16 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Ely Aesthetics Legacy</title>
+    <meta
+      name="description"
+      content="Legacy version of the Ely Aesthetics homepage with previous design."
+    />
+    <meta
+      name="keywords"
+      content="Ely Aesthetics, facial spa, skincare, Yuma Arizona"
+    />
     <link rel="stylesheet" href="style.css" />
   </head>
   <body>


### PR DESCRIPTION
## Summary
- add SEO keywords and viewport exports in the Next.js layout
- define page-specific metadata for the homepage
- supply meta tags on the legacy HTML page

## Testing
- `npm run build`