### PR TITLE
Fix Instagram embed URLs

### DIFF
--- a/app/components/InstagramCarousel.jsx
+++ b/app/components/InstagramCarousel.jsx
@@ -27,7 +27,7 @@ export default function InstagramCarousel() {
   useEffect(() => {
     if (!window.instgrm) {
       const s = document.createElement('script')
-      s.src = '//www.instagram.com/embed.js'
+      s.src = 'https://www.instagram.com/embed.js'
       s.async = true
       s.onload = () => window.instgrm?.Embeds?.process()
       document.body.appendChild(s)

--- a/app/components/SocialSection.jsx
+++ b/app/components/SocialSection.jsx
@@ -9,7 +9,7 @@ export default function SocialSection() {
   useEffect(() => {
     if (!window.instgrm) {
       const script = document.createElement('script')
-      script.src = '//www.instagram.com/embed.js'
+      script.src = 'https://www.instagram.com/embed.js'
       script.async = true
       script.onload = () => {
         if (window.instgrm?.Embeds?.process) {


### PR DESCRIPTION
## Summary
- use HTTPS for Instagram embed script in both SocialSection and InstagramCarousel

## Testing
- `npm test` *(fails: Missing script)*