### PR TITLE
Fix homepage import usage

### DIFF
--- a/app/page.jsx
+++ b/app/page.jsx
@@ -1,5 +1,4 @@
 // app/page.js
-import Script from 'next/script'
 import SocialSection from './components/SocialSection'
 import InstagramCarousel from './components/InstagramCarousel'
 import AboutSection from './components/AboutSection'


### PR DESCRIPTION
## Summary
- remove unused Script import from the homepage

## Testing
- `npm test` *(fails: missing script)*
- `npm run build`