### PR TITLE
Add dynamic SaleBanner config

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -1,6 +1,8 @@
 // app/layout.js
 import '../styles/style.css'
 import Script from 'next/script'
+import SaleBanner from '@components/SaleBanner'
+import bannerConfig from '@content/banner.json'
 
 export const metadata = {
   title: 'Ely Aesthetics',
@@ -22,6 +24,13 @@ export default function RootLayout({ children }) {
     <html lang="en">
       <head />
       <body>
+
+        <SaleBanner
+          message={bannerConfig.message}
+          enabled={bannerConfig.enabled}
+          sticky={bannerConfig.sticky}
+          id={bannerConfig.id}
+        />
 
         {/* Page Content */}
         <main>

--- a/content/banner.json
+++ b/content/banner.json
@@ -1,0 +1,6 @@
+{
+  "message": "Summer Special: 20% off all treatments!",
+  "enabled": true,
+  "sticky": true,
+  "id": "summer-special"
+}


### PR DESCRIPTION
## Summary
- create content/banner.json for sale banner settings
- show SaleBanner at top of layout using config

## Testing
- `npm run build` *(fails: `next` not found)*