### PR TITLE
Fix mobile hero overlay coverage

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -197,9 +197,12 @@ nav a.active {
 .hero::before {
   content: '';
   position: absolute;
-  top: 0; left: 0;
-  width: 100%; height: 100%;
-  background-color: rgba(0,0,0,0.2);
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.2);
+  pointer-events: none;
   z-index: 1;
 }
 /* Base mobile typography and padding */
@@ -207,7 +210,7 @@ nav a.active {
   position: relative;
   z-index: 2;
   background-color: rgba(255, 255, 255, 0.5);
-  padding: 0 1.2rem;
+  padding: 0 1.2rem 4.5rem;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -438,7 +441,7 @@ nav a.active {
   }
   /* Hero typography up‑scaled */
   .hero-content {
-    padding: 2rem 1.5rem;
+    padding: 2rem 1.5rem 2rem;
   }
   .hero-content h1 {
     font-size: 2.25rem;
@@ -462,7 +465,7 @@ nav a.active {
     padding-bottom: 1rem;
   }
   .hero-content {
-    padding: 0 0.5rem;
+    padding: 0 0.5rem 4.5rem;
   }
 }
 
@@ -473,7 +476,7 @@ nav a.active {
   }
   .hero-content {
     width: 100%;
-    padding: 1.25rem 0.75rem;
+    padding: 1.25rem 0.75rem 4.5rem;
   }
   .hero-content h1 {
     font-size: 1.5rem;
@@ -504,7 +507,7 @@ nav a.active {
     width: 50%;
   }
   .hero-content {
-    padding: 3rem 2rem;
+    padding: 3rem 2rem 2rem;
   }
   .hero-content h1 {
     font-size: 2.75rem;


### PR DESCRIPTION
## Summary
- overlay covers entire hero section and doesn't stop at text
- add extra bottom padding for hero overlay on mobile
- adjust padding on larger screens

## Testing
- `npm test` *(fails: Missing script)*