### PR TITLE
Add accessible AccordionFAQ component

### DIFF
--- a/app/components/AccordionFAQ.jsx
+++ b/app/components/AccordionFAQ.jsx
@@ -1,17 +1,37 @@
 'use client'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 
-export default function FAQAccordion({ items = [] }) {
+// AccordionFAQ supports only one open item at a time, per a11y best practices.
+export default function AccordionFAQ({ items = [] }) {
   const [open, setOpen] = useState(null)
+  const buttonRefs = useRef([])
 
   const toggle = (idx) => {
     setOpen(open === idx ? null : idx)
   }
 
   const handleKey = (e, idx) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault()
-      toggle(idx)
+    switch (e.key) {
+      case 'ArrowDown': {
+        e.preventDefault()
+        const next = (idx + 1) % items.length
+        buttonRefs.current[next]?.focus()
+        break
+      }
+      case 'ArrowUp': {
+        e.preventDefault()
+        const prev = (idx - 1 + items.length) % items.length
+        buttonRefs.current[prev]?.focus()
+        break
+      }
+      case 'Enter':
+      case ' ': {
+        e.preventDefault()
+        toggle(idx)
+        break
+      }
+      default:
+        break
     }
   }
 
@@ -22,6 +42,7 @@ export default function FAQAccordion({ items = [] }) {
         return (
           <div className="faq-item" key={id}>
             <button
+              ref={el => (buttonRefs.current[idx] = el)}
               className="faq-question"
               aria-expanded={open === idx}
               aria-controls={`${id}-panel`}

--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -1,4 +1,4 @@
-import FAQAccordion from '@components/FAQAccordion'
+import AccordionFAQ from '@components/AccordionFAQ'
 import { notFound } from 'next/navigation'
 
 const bookingUrl = 'https://mysite.vagaro.com/sweetcreamandrose/book-now'
@@ -165,7 +165,7 @@ export default function ServicePage({ params }) {
 
         <section>
           <h2>FAQ</h2>
-          <FAQAccordion items={faqs} />
+          <AccordionFAQ items={faqs} />
         </section>
 
         <section className="testimonial">


### PR DESCRIPTION
## Summary
- add new AccordionFAQ component with arrow key navigation and aria labels
- update service pages to use AccordionFAQ

## Testing
- `npm run build`
