### PR TITLE
Fix sale banner visibility logic

### DIFF
--- a/app/components/SaleBanner.jsx
+++ b/app/components/SaleBanner.jsx
@@ -3,18 +3,16 @@ import { useEffect, useState } from 'react'
 import styles from './SaleBanner.module.css'
 
 export default function SaleBanner({ message = '', enabled = false, sticky = false, id = 'default' }) {
-  const storageKey = `saleBannerDismissed_${id}`
   const [visible, setVisible] = useState(false)
 
   useEffect(() => {
     if (enabled && message && message.trim().length > 0) {
-      setVisible(!window.localStorage.getItem(storageKey))
+      setVisible(true)
     }
-  }, [enabled, message, id])
+  }, [enabled, message])
 
   function handleClose() {
     setVisible(false)
-    window.localStorage.setItem(storageKey, 'true')
   }
 
   const displayMessage = message?.slice(0, 90)


### PR DESCRIPTION
## Summary
- show sale banner every time the page loads

## Testing
- `npm run build`