### PR TITLE
Update ServiceHero to use ctaHref

### DIFF
--- a/app/components/ServiceHero.jsx
+++ b/app/components/ServiceHero.jsx
@@ -7,7 +7,7 @@ export default function ServiceHero({
   imageSrc,
   imageAlt,
   ctaText,
-  onCtaClick,
+  ctaHref,
 }) {
   return (
     <section className="service-hero">
@@ -19,9 +19,14 @@ export default function ServiceHero({
         {headline && <p>{headline}</p>}
         {description && <p>{description}</p>}
         {ctaText && (
-          <button className="btn btn-primary" onClick={onCtaClick}>
+          <a
+            className="btn btn-primary"
+            href={ctaHref}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
             {ctaText}
-          </button>
+          </a>
         )}
       </div>
     </section>

--- a/app/services/anti-age-peptide-peel/page.jsx
+++ b/app/services/anti-age-peptide-peel/page.jsx
@@ -57,13 +57,7 @@ export default function AntiAgePeptidePeelPage() {
         imageSrc="/images/anti_age.jpeg"
         imageAlt="Anti-Age Peptide Peel"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">

--- a/app/services/customized-facial/page.jsx
+++ b/app/services/customized-facial/page.jsx
@@ -57,13 +57,7 @@ export default function CustomizedFacialPage() {
         imageSrc="/images/before-after-1.jpeg"
         imageAlt="Customized Facial"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">

--- a/app/services/hydrafacial/page.jsx
+++ b/app/services/hydrafacial/page.jsx
@@ -57,13 +57,7 @@ export default function HydrafacialPage() {
         imageSrc="/images/hydrafacial.jpg"
         imageAlt="Platinum Hydrafacial"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">

--- a/app/services/microneedling/page.jsx
+++ b/app/services/microneedling/page.jsx
@@ -73,13 +73,7 @@ export default function MicroneedlingPage() {
         imageSrc="/images/microneedling-before-after.jpeg"
         imageAlt="Microneedling"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">

--- a/app/services/rose-glow-dermaplaning/page.jsx
+++ b/app/services/rose-glow-dermaplaning/page.jsx
@@ -57,13 +57,7 @@ export default function RoseGlowDermaplaningPage() {
         imageSrc="/images/dermaplaning-before-after.jpeg"
         imageAlt="Rose Glow Dermaplaning Facial"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">

--- a/app/services/skinbetter-peel/page.jsx
+++ b/app/services/skinbetter-peel/page.jsx
@@ -62,13 +62,7 @@ export default function SkinbetterPeelPage() {
         imageSrc="/images/peel.jpeg"
         imageAlt="Skinbetter Peel"
         ctaText="Book Now"
-        onCtaClick={() =>
-          window.open(
-            'https://www.vagaro.com/elyaesthetics',
-            '_blank',
-            'noopener'
-          )
-        }
+        ctaHref="https://www.vagaro.com/elyaesthetics"
       />
 
       <div className="service-content container">


### PR DESCRIPTION
## Summary
- update `ServiceHero` component API to accept `ctaHref`
- update service pages to use `ctaHref` instead of `onCtaClick`

## Testing
- `npm run build` *(fails: Page "/services/[slug]/page" cannot use both "use client" and export function "generateStaticParams()".)*