### PR TITLE
Refactor: Standardize service page styles and structure

### DIFF
--- a/app/services/ServicePage.module.css
+++ b/app/services/ServicePage.module.css
@@ -1,0 +1,45 @@
+.aboutSection {
+  padding: 2rem 1rem;
+}
+
+.benefitsSection {
+  padding: 2rem 1rem;
+}
+
+.benefitsTitle {
+  font-family: var(--font-primary, Montserrat), sans-serif;
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: var(--color-accent, #265740);
+  margin-bottom: 1rem;
+}
+
+.benefitsList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.benefitItem {
+  display: flex;
+  align-items: center;
+  margin-bottom: 0.75rem;
+}
+
+.benefitIcon {
+  width: 1.25rem;
+  height: 1.25rem;
+  flex-shrink: 0;
+  margin-right: 0.5rem;
+  fill: var(--color-accent, #265740);
+}
+
+.benefitText {
+  font-family: var(--font-secondary, "Open Sans"), sans-serif;
+  color: #333;
+  font-size: 1rem;
+}
+
+.faqSection {
+  padding: 2rem 1rem;
+}

--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import { notFound } from 'next/navigation'
+import styles from '../ServicePage.module.css';
 
 const bookingUrl = 'https://mysite.vagaro.com/sweetcreamandrose/book-now'
 
@@ -138,10 +139,25 @@ export default function ServicePage({ params }) {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About {name}</h2>
+          <p>{headline}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -154,8 +170,8 @@ export default function ServicePage({ params }) {
         </figure>
 
         {serviceFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={serviceFAQs} />
           </section>
         )}

--- a/app/services/anti-age-peptide-peel/page.jsx
+++ b/app/services/anti-age-peptide-peel/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
+import styles from '../ServicePage.module.css';
 
 // About text for this service
 const aboutText = `This treatment pairs mild exfoliation with powerful peptides to promote firm, supple skin. Regular sessions smooth wrinkles and even out tone.`
@@ -55,10 +56,25 @@ export default function AntiAgePeptidePeelPage() {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About Anti-Age Peptide Peel</h2>
+          <p>{aboutText}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -71,8 +87,8 @@ export default function AntiAgePeptidePeelPage() {
         </figure>
 
         {antiAgePeptidePeelFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={antiAgePeptidePeelFAQs} />
           </section>
         )}

--- a/app/services/customized-facial/page.jsx
+++ b/app/services/customized-facial/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
+import styles from '../ServicePage.module.css';
 
 // About text for this service
 const aboutText = `Tailored facials combining various treatments to address individual skin concerns and enhance overall skin health.`
@@ -55,10 +56,25 @@ export default function CustomizedFacialPage() {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About Customized Facial</h2>
+          <p>{aboutText}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -71,8 +87,8 @@ export default function CustomizedFacialPage() {
         </figure>
 
         {customizedFacialFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={customizedFacialFAQs} />
           </section>
         )}

--- a/app/services/hydrafacial/page.jsx
+++ b/app/services/hydrafacial/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
+import styles from '../ServicePage.module.css';
 
 // About text for this service
 const aboutText = `Hydrafacials deeply cleanse, exfoliate, and hydrate the skin, effectively addressing acne, dryness, and signs of aging.`
@@ -55,10 +56,25 @@ export default function HydrafacialPage() {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About Platinum Hydrafacial</h2>
+          <p>{aboutText}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -71,8 +87,8 @@ export default function HydrafacialPage() {
         </figure>
 
         {hydrafacialFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={hydrafacialFAQs} />
           </section>
         )}

--- a/app/services/microneedling/page.jsx
+++ b/app/services/microneedling/page.jsx
@@ -1,6 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
-import styles from './ServicePage.module.css'
+import styles from '../ServicePage.module.css'
 
 // About text for Microneedling
 const aboutText = `Our Microneedling treatment, also known as Collagen Induction Therapy, is a highly effective method that tightens, restores, rejuvenates, and diminishes the signs of aging using our medical grade, FDA approved Skinpen. By creating thousands of micro-channels to puncture the skin, this treatment ensures even and luminous healed skin. Recommended in a series of three sessions, 4 weeks apart.`;

--- a/app/services/rose-glow-dermaplaning/page.jsx
+++ b/app/services/rose-glow-dermaplaning/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
+import styles from '../ServicePage.module.css';
 
 // About text for this service
 const aboutText = `Dermaplaning gently exfoliates dead skin cells and removes fine hair, revealing a smoother, brighter complexion.`
@@ -55,10 +56,25 @@ export default function RoseGlowDermaplaningPage() {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About Rose Glow Dermaplaning Facial</h2>
+          <p>{aboutText}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -71,8 +87,8 @@ export default function RoseGlowDermaplaningPage() {
         </figure>
 
         {roseGlowDermaplaningFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={roseGlowDermaplaningFAQs} />
           </section>
         )}

--- a/app/services/skinbetter-peel/page.jsx
+++ b/app/services/skinbetter-peel/page.jsx
@@ -1,5 +1,6 @@
 import AccordionFAQ from '@/components/AccordionFAQ'
 import Nav from '../../components/Nav'
+import styles from '../ServicePage.module.css';
 
 // About text for this service
 const aboutText = `The Skinbetter Peel gently resurfaces using medical grade acids for improved tone and clarity. A series of peels can dramatically smooth texture and fade pigmentation.`
@@ -60,10 +61,25 @@ export default function SkinbetterPeelPage() {
       <Nav />
 
       <div className="service-content container">
-        <section>
-          <h2>Key Benefits</h2>
-          <ul>
-            {benefits.map((b) => <li key={b}>{b}</li>)}
+        <section className={styles.aboutSection}>
+          <h2>About Skinbetter Peel</h2>
+          <p>{aboutText}</p>
+        </section>
+        <section className={styles.benefitsSection}>
+          <h2 className={styles.benefitsTitle}>Key Benefits</h2>
+          <ul className={styles.benefitsList}>
+            {benefits.map((b) => (
+              <li key={b} className={styles.benefitItem}>
+                <svg
+                  className={styles.benefitIcon}
+                  aria-hidden="true"
+                  viewBox="0 0 24 24"
+                >
+                  <path d="M9 16.17l-3.5-3.5L4 14.17 9 19.17 20 8.17 18.59 6.75z" />
+                </svg>
+                <span className={styles.benefitText}>{b}</span>
+              </li>
+            ))}
           </ul>
         </section>
 
@@ -76,8 +92,8 @@ export default function SkinbetterPeelPage() {
         </figure>
 
         {skinbetterPeelFAQs.length > 0 && (
-          <section>
-            <h2 className="faq-heading">Frequently Asked Questions</h2>
+          <section className={styles.faqSection}>
+            <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={skinbetterPeelFAQs} />
           </section>
         )}


### PR DESCRIPTION
- I moved ServicePage.module.css to a shared location (`app/services/`) and updated all service page imports.
- I ensured all service pages (`hydrafacial`, `customized-facial`, `anti-age-peptide-peel`, `rose-glow-dermaplaning`, `skinbetter-peel`, and `[slug]`) render an `<section className={styles.aboutSection}>`.
- I wrapped benefits lists in `<section className={styles.benefitsSection}>` and applied consistent check-icon markup and styling.
- I ensured FAQ sections use `className={styles.faqSection}` and have a standardized heading.
- I verified the build after correcting an import path in `[slug]/page.jsx`.