### PR TITLE
Remove before-after images and testimonials from service pages

### DIFF
--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -19,7 +19,6 @@ const services = {
       { q: 'How many sessions do I need?', a: 'Most clients see best results after 3–6 visits.' },
       { q: 'Is there downtime?', a: 'Expect some redness for about a day.' }
     ],
-    testimonial: { text: 'Microneedling with Elyzia transformed my acne scars!', author: 'Sofia R.' }
   },
   'skinbetter-peel': {
     name: 'Skinbetter Peel',
@@ -37,7 +36,6 @@ const services = {
       { q: 'Will I peel a lot?', a: 'Most experience only light flaking for a few days.' },
       { q: 'How often should I get one?', a: 'Peels are typically spaced 4–6 weeks apart.' }
     ],
-    testimonial: { text: 'My skin glows after each peel!', author: 'Andrea M.' }
   },
   'anti-age-peptide-peel': {
     name: 'Anti-Age Peptide Peel Treatment',
@@ -55,7 +53,6 @@ const services = {
       { q: 'Is it good for sensitive skin?', a: "Yes, it's designed to be gentle while still effective." },
       { q: 'How quickly will I see results?', a: 'Skin looks refreshed after one treatment with cumulative benefits over time.' }
     ],
-    testimonial: { text: 'I love how smooth my skin feels!', author: 'Lily S.' }
   },
   'rose-glow-dermaplaning': {
     name: 'Rose Glow Dermaplaning Facial',
@@ -72,7 +69,6 @@ const services = {
       { q: 'Will my hair grow back thicker?', a: 'No, dermaplaning will not change hair growth.' },
       { q: 'How often can I have this done?', a: 'Every 4 weeks is ideal for maintaining smooth skin.' }
     ],
-    testimonial: { text: "Best facial I've had—my makeup glides on flawlessly!", author: 'Melissa T.' }
   },
   hydrafacial: {
     name: 'Platinum Hydrafacial',
@@ -89,7 +85,6 @@ const services = {
       { q: 'Is it safe for sensitive skin?', a: "Yes, the treatment is adjustable to your skin's needs." },
       { q: 'How long does it take?', a: 'About 60 minutes from start to finish.' }
     ],
-    testimonial: { text: 'My skin has never looked better after a Hydrafacial!', author: 'Jason P.' }
   },
   'customized-facial': {
     name: 'Customized Facial',
@@ -106,7 +101,6 @@ const services = {
       { q: 'What products are used?', a: 'We select professional-grade formulas based on your skin type.' },
       { q: 'Can I combine this with other treatments?', a: "Yes, it's a great complement to peels or microneedling." }
     ],
-    testimonial: { text: 'Elyzia always knows exactly what my skin needs!', author: 'Carmen L.' }
   }
 }
 
@@ -129,7 +123,7 @@ export default function ServicePage({ params }) {
 
   if (!data) return notFound()
 
-  const { name, headline, benefits, description, faqs, testimonial } = data
+  const { name, headline, benefits, description, faqs } = data
   const serviceFAQs = faqs
 
   return (
@@ -163,10 +157,6 @@ export default function ServicePage({ params }) {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src={`/images/services/${params.slug}-beforeafter.jpg`} alt={`Before and after ${name} result`} />
-        </figure>
-
         {serviceFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
@@ -174,10 +164,6 @@ export default function ServicePage({ params }) {
           </section>
         )}
 
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          {testimonial.author && <cite>- {testimonial.author}</cite>}
-        </section>
       </div>
 
       <div className="sticky-cta">

--- a/app/services/customized-facial/page.jsx
+++ b/app/services/customized-facial/page.jsx
@@ -17,10 +17,6 @@ const description = [
   'Tailored facials combining various treatments to address individual skin concerns and enhance overall skin health.'
 ]
 
-const testimonial = {
-  text: 'Elyzia always knows exactly what my skin needs!',
-  author: 'Carmen L.'
-}
 const customizedFacialFAQs = [
   {
     q: 'What is included in a Customized Facial?',
@@ -81,21 +77,12 @@ export default function CustomizedFacialPage() {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src="/images/services/customized-facial-beforeafter.jpg" alt="Before and after Customized Facial result" />
-        </figure>
-
         {customizedFacialFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={customizedFacialFAQs} />
           </section>
         )}
-
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          <cite>- {testimonial.author}</cite>
-        </section>
       </div>
 
       <div className="sticky-cta">

--- a/app/services/hydrafacial/page.jsx
+++ b/app/services/hydrafacial/page.jsx
@@ -17,10 +17,6 @@ const description = [
   'Hydrafacials deeply cleanse, exfoliate, and hydrate the skin, effectively addressing acne, dryness, and signs of aging.'
 ]
 
-const testimonial = {
-  text: 'My skin has never looked better after a Hydrafacial!',
-  author: 'Jason P.'
-}
 const hydrafacialFAQs = [
   {
     q: 'What is a Platinum Hydrafacial?',
@@ -81,21 +77,12 @@ export default function HydrafacialPage() {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src="/images/services/hydrafacial-beforeafter.jpg" alt="Before and after Platinum Hydrafacial result" />
-        </figure>
-
         {hydrafacialFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
             <AccordionFAQ faqs={hydrafacialFAQs} />
           </section>
         )}
-
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          <cite>- {testimonial.author}</cite>
-        </section>
       </div>
 
       <div className="sticky-cta">

--- a/app/services/microneedling/page.jsx
+++ b/app/services/microneedling/page.jsx
@@ -18,10 +18,6 @@ const description = [
   'Microneedling stimulates collagen production, improving skin texture and reducing fine lines for a youthful appearance.'
 ]
 
-const testimonial = {
-  text: 'Microneedling with Elyzia transformed my acne scars!',
-  author: 'Sofia R.'
-}
 
 const microneedlingFAQs = [
   {
@@ -104,10 +100,6 @@ export default function MicroneedlingPage() {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src="/images/services/microneedling-beforeafter.jpg" alt="Before and after Microneedling result" />
-        </figure>
-
         {microneedlingFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
@@ -115,10 +107,6 @@ export default function MicroneedlingPage() {
           </section>
         )}
 
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          <cite>- {testimonial.author}</cite>
-        </section>
       </div>
 
       <div className="sticky-cta">

--- a/app/services/rose-glow-dermaplaning/page.jsx
+++ b/app/services/rose-glow-dermaplaning/page.jsx
@@ -17,10 +17,6 @@ const description = [
   'Dermaplaning gently exfoliates dead skin cells and removes fine hair, revealing a smoother, brighter complexion.'
 ]
 
-const testimonial = {
-  text: "Best facial I've had—my makeup glides on flawlessly!",
-  author: 'Melissa T.'
-}
 const roseGlowDermaplaningFAQs = [
   {
     q: 'What is dermaplaning?',
@@ -81,10 +77,6 @@ export default function RoseGlowDermaplaningPage() {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src="/images/services/rose-glow-dermaplaning-beforeafter.jpg" alt="Before and after Rose Glow Dermaplaning Facial result" />
-        </figure>
-
         {roseGlowDermaplaningFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
@@ -92,10 +84,6 @@ export default function RoseGlowDermaplaningPage() {
           </section>
         )}
 
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          <cite>- {testimonial.author}</cite>
-        </section>
       </div>
 
       <div className="sticky-cta">

--- a/app/services/skinbetter-peel/page.jsx
+++ b/app/services/skinbetter-peel/page.jsx
@@ -18,10 +18,6 @@ const description = [
   'A series of peels can dramatically smooth texture and fade pigmentation.'
 ]
 
-const testimonial = {
-  text: 'My skin glows after each peel!',
-  author: 'Andrea M.'
-}
 const skinbetterPeelFAQs = [
   {
     q: 'What is a Skinbetter Peel?',
@@ -86,10 +82,6 @@ export default function SkinbetterPeelPage() {
           {description.map((p, i) => <p key={i}>{p}</p>)}
         </section>
 
-        <figure className="before-after">
-          <img src="/images/services/skinbetter-peel-beforeafter.jpg" alt="Before and after Skinbetter Peel result" />
-        </figure>
-
         {skinbetterPeelFAQs.length > 0 && (
           <section className={styles.faqSection}>
             <h2>Frequently Asked Questions</h2>
@@ -97,10 +89,6 @@ export default function SkinbetterPeelPage() {
           </section>
         )}
 
-        <section className="testimonial">
-          <blockquote>{testimonial.text}</blockquote>
-          <cite>- {testimonial.author}</cite>
-        </section>
       </div>
 
       <div className="sticky-cta">


### PR DESCRIPTION
## Summary
- clean up service pages to match the Anti‑Age Peptide Peel layout
- drop unused testimonial data and before/after images

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683a1b525e288327ae36cfc718877612