### PR TITLE
Remove About from service page headings

### DIFF
--- a/app/services/[slug]/page.jsx
+++ b/app/services/[slug]/page.jsx
@@ -132,7 +132,7 @@ export default function ServicePage({ params }) {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About {name}</h2>
+          <h2>{name}</h2>
           <p>{headline}</p>
         </section>
         <section className={styles.benefitsSection}>

--- a/app/services/customized-facial/page.jsx
+++ b/app/services/customized-facial/page.jsx
@@ -47,7 +47,7 @@ export default function CustomizedFacialPage() {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About Customized Facial</h2>
+          <h2>Customized Facial</h2>
           <p>{aboutText}</p>
         </section>
         <section className={styles.benefitsSection}>

--- a/app/services/hydrafacial/page.jsx
+++ b/app/services/hydrafacial/page.jsx
@@ -68,7 +68,7 @@ export default function HydrafacialPage() {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About Platinum Hydrafacial</h2>
+          <h2>Platinum Hydrafacial</h2>
           <p>{aboutText}</p>
         </section>
         <section className={styles.benefitsSection}>

--- a/app/services/microneedling/page.jsx
+++ b/app/services/microneedling/page.jsx
@@ -68,7 +68,7 @@ export default function MicroneedlingPage() {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About Microneedling</h2>
+          <h2>Microneedling</h2>
           <p>{aboutText}</p>
         </section>
 

--- a/app/services/rose-glow-dermaplaning/page.jsx
+++ b/app/services/rose-glow-dermaplaning/page.jsx
@@ -47,7 +47,7 @@ export default function RoseGlowDermaplaningPage() {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About Rose Glow Dermaplaning Facial</h2>
+          <h2>Rose Glow Dermaplaning Facial</h2>
           <p>{aboutText}</p>
         </section>
         <section className={styles.benefitsSection}>

--- a/app/services/skinbetter-peel/page.jsx
+++ b/app/services/skinbetter-peel/page.jsx
@@ -50,7 +50,7 @@ export default function SkinbetterPeelPage() {
 
       <div className="service-content container">
         <section className={styles.aboutSection}>
-          <h2>About Skinbetter Peel</h2>
+          <h2>Skinbetter Peel</h2>
           <p>{aboutText}</p>
         </section>
         <section className={styles.benefitsSection}>


### PR DESCRIPTION
## Summary
- strip the word "About" from service page headings

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683b5d2f3e8483278785c9a1198e4c93